### PR TITLE
Update screen-orientation.ios.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-screen-orientation",
-  "version": “1.0.1”,
+  "version": "1.0.1",
   "description": "A plugin to force change the orientation of a page programmatically in NativeScript. Supports both Android and iOS.",
   "main": "screen-orientation.js",
   "nativescript": {

--- a/screen-orientation.ios.js
+++ b/screen-orientation.ios.js
@@ -101,13 +101,17 @@ function setOrientationsForViewControllers(){
 
     };
 
+    if("landscape"==orientationType){
+        UIDevice.currentDevice().setValueForKey(UIInterfaceOrientation.UIInterfaceOrientationLandscapeRight, "orientation")
+    }
+    if("portrait"==orientationType){
+        UIDevice.currentDevice().setValueForKey(UIInterfaceOrientation.UIInterfaceOrientationPortrait, "orientation")
+    }if("all"==orientationType){
+        //no-op
+    }if("allbutupsidedown"==orientationType){
+        //no-op
+    }
 
-    var window=UIApplication.sharedApplication().windows.objectAtIndex(0),
-        rootController=window.rootViewController,
-        tempmodal=UIViewController.alloc().init();
-
-    rootController.presentViewControllerAnimatedCompletion(tempmodal,false,null);
-    rootController.dismissViewControllerAnimatedCompletion(false,completionCallback);
 
     //if(completionCallback){
     //    completionCallback();


### PR DESCRIPTION
The removed lines caused our app to crash on iOS 9.3.2.
We used a workaround for forcing the interface orientation to change.
