### PR TITLE
Fix error path require "ui/frame" in IOS

### DIFF
--- a/screen-orientation.ios.js
+++ b/screen-orientation.ios.js
@@ -3,7 +3,7 @@
  */
 
 
-var frameModule = require("ui/frame");
+var frameModule = require("tns-core-modules/ui/frame");
 
 
 /**


### PR DESCRIPTION
ERROR:
NativeScript encountered a fatal error: TypeError: undefined is not an object (evaluating 'frameModule.topmost().ios')


I needed to change the screen-orientation.ios.js file.

Where it is written:
var frameModule = require ("ui/frame");

I updated to:
var frameModule = require ("tns-core-modules/ui/frame");

After this update worked correctly.